### PR TITLE
fix(examples): input text on dark mode is not visible

### DIFF
--- a/pages/examples/login.js
+++ b/pages/examples/login.js
@@ -50,7 +50,7 @@ export default function Login () {
                   ref={emailRef}
                   required
                   autoComplete="email"
-                  className="shadow appearance-none border rounded w-full py-2 px-3 text-grey-darker"
+                  className="shadow appearance-none border rounded w-full py-2 px-3 text-grey-darker dark:bg-gray-700"
                   id="email"
                   type="text"
                 />
@@ -63,7 +63,7 @@ export default function Login () {
                   ref={passwordRef}
                   required
                   autoComplete="new-password"
-                  className="shadow appearance-none border rounded w-full py-2 px-3 text-grey-darker mb-3"
+                  className="shadow appearance-none border rounded w-full py-2 px-3 text-grey-darker dark:bg-gray-700 mb-3"
                   id="password"
                   type="password"
                 />


### PR DESCRIPTION
When I tried the example of this post "Pengujian performa web untuk halaman dengan login", I thought I already pasted the email and password but nothing visible on the input. It turned out that the text is already pasted several times, the input text color make it looks like invisible.

![Screenshot from 2021-08-21 22-20-00](https://user-images.githubusercontent.com/20434351/130326505-c8d34aab-a4eb-43eb-8955-471e5304c706.png)

It uses color taken from toggle dark mode button.

After:
![Screenshot from 2021-08-21 22-17-23](https://user-images.githubusercontent.com/20434351/130326434-18c3abaa-2a19-47d5-8c8b-f1e2269372a0.png)
