### PR TITLE
Fixed UI of repo stars in about page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -101,9 +101,9 @@ export default function AboutPage() {
                   </a>
                   <p className="mb-4 text-sm">{oss.desc}</p>
 
-                  <div className="flex justify-between">
+                  <div className="flex justify-between items-center">
                     <a
-                      className="hover:underline text-red-500 text-sm"
+                      className="hover:underline text-red-500 text-sm truncate"
                       target="_blank"
                       rel="noopener noreferrer"
                       href={oss.repo}


### PR DESCRIPTION
Closes #152

## Description

The repo stars UI in about page is not responsive on medium screens.

## Current Tasks

- Changed the alignment of the element containing the repo stars.
- Added a change to the anchor tag containing repo link so that an ellipsis (...) is shown in case of text overflow.

## Screenshots

|  |  |
| - | - |
| Before | ![screenshot1](https://github.com/mazipan/mazipan.space/assets/107102771/908b7ca2-25fd-4c37-98d2-46ea3205a475) |
| After | ![screenshot](https://github.com/mazipan/mazipan.space/assets/107102771/4695183c-8af0-4aab-bce7-52cfd51f85ae) |
