### PR TITLE
removed the link from footer and support

### DIFF
--- a/components/FooterSection.js
+++ b/components/FooterSection.js
@@ -17,10 +17,6 @@ export default function Footer() {
       <SocialIcons />
 
       <div className="flex gap-2 my-2 justify-center items-center">
-        <a href="https://www.nihbuatjajan.com/mazipan" target="_blank" rel="noreferrer noopener">
-          <img loading="lazy" height={30} width={110} src="https://d4xyvrfd64gfm.cloudfront.net/buttons/default-cta.png" alt="Nih buat jajan" style={{ border: '0px' }} />
-        </a>
-
         <a href="https://trakteer.id/mazipan" target="_blank" rel="noreferrer noopener">
           <img loading="lazy" height={30} width={100} id="wse-buttons-preview" src="https://cdn.trakteer.id/images/embed/trbtn-red-1.png" style={{ border: '0px' }} alt="Trakteer Saya" />
         </a>

--- a/pages/support.js
+++ b/pages/support.js
@@ -29,16 +29,7 @@ export default function Index () {
                   <span className="mr-2">🇮🇩</span> Trakteer
                 </a>
               </li>
-              <li>
-                <span className="mr-2">👉</span>
-                <a
-                  className="text-red-500 hover:underline pr-2 md:pr-4"
-                  href="https://www.nihbuatjajan.com/mazipan?utm_source=mazipan.space"
-                  rel="nofollow"
-                >
-                  <span className="mr-2">🇮🇩</span> NihBuatJajan
-                </a>
-              </li>
+              
               <li>
                 <span className="mr-2">👉</span>
                 <a


### PR DESCRIPTION
Closes #158 

## Description

This PR removes the "NihBuatJajan" link from both the support page and the footer as per the request in issue #158. The link was deemed unnecessary, and its removal simplifies the user interface. No other functionality was affected by this change.

## Current Tasks

- [x] Removed "NihBuatJajan" link from the support page.
- [x] Removed "NihBuatJajan" link from the footer.
- [ ] Review and test to ensure that no unintended UI or functional issues arose from the removal.
