### PR TITLE
feat(footer): add tools.mazipan.space link

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -126,6 +126,16 @@ const copyrightYear = new Date().getFullYear();
             </li>
             <li>
               <Link
+                href={ROUTES.TOOLS}
+                target="_blank"
+                rel="me noreferrer noopener"
+                title="Tools collections"
+              >
+                Tools
+              </Link>
+            </li>
+            <li>
+              <Link
                 href={AUTHOR_ADPLIST}
                 title="Meet me at ADPList"
                 target="_blank"

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -37,5 +37,6 @@ export const ROUTES = {
   },
   UMAMI_PUBLIC_URL: 'https://umami.mazipan.space/share/O3odIJMu00TRHGhb/www.mazipan.space',
   BOOKMARKS: 'https://bookmarks.mazipan.space/',
+  TOOLS: 'https://tools.mazipan.space/',
   GH_NEW_ISSUE: 'https://github.com/mazipan/mazipan.space/issues/new',
 } as const;


### PR DESCRIPTION
Surface the new tools subdomain from the site footer alongside the existing bookmarks entry so visitors can discover it.

https://claude.ai/code/session_01ScA9K3xE7P8LQksUnhN3LM