### PR TITLE
Add TranslatorButton component for blog posts

### DIFF
--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -26,7 +26,8 @@ const isAlreadyEnglish = lang === 'en';
 }
 
 <script>
-  const CONTENT_SELECTOR = '.my-prose';
+  const TRANSLATABLE_ATTR = '[data-translatable]';
+  const CONTENT_SELECTOR = '[data-translatable="content"]';
   const TARGET_LANG = 'en';
 
   interface TranslatorInstance {
@@ -110,19 +111,25 @@ const isAlreadyEnglish = lang === 'en';
         }
         console.debug('[TranslatorButton] Translator ready');
 
-        const contentEl = document.querySelector(CONTENT_SELECTOR);
+        // Collect all translatable sections in order: title, description, then content blocks
+        const heroEls = Array.from(
+          document.querySelectorAll<HTMLElement>(`${TRANSLATABLE_ATTR}:not([data-translatable="content"])`)
+        );
+
+        const contentEl = document.querySelector<HTMLElement>(CONTENT_SELECTOR);
         if (!contentEl) {
           throw new Error(`Content element not found: ${CONTENT_SELECTOR}`);
         }
 
-        const blocks = Array.from(
+        const contentBlocks = Array.from(
           contentEl.querySelectorAll<HTMLElement>('p, h1, h2, h3, h4, h5, h6, li, blockquote, td, th')
         ).filter((el) => !el.closest('pre'));
 
-        console.debug(`[TranslatorButton] Found ${blocks.length} blocks to translate`);
+        const allBlocks = [...heroEls, ...contentBlocks];
+        console.debug(`[TranslatorButton] Found ${heroEls.length} hero + ${contentBlocks.length} content blocks = ${allBlocks.length} total`);
 
-        for (let b = 0; b < blocks.length; b++) {
-          const block = blocks[b];
+        for (let b = 0; b < allBlocks.length; b++) {
+          const block = allBlocks[b];
           const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, {
             acceptNode(node) {
               const text = node.textContent?.trim();
@@ -141,7 +148,7 @@ const isAlreadyEnglish = lang === 'en';
           }
           if (!textNodes.length) continue;
 
-          console.debug(`[TranslatorButton] Translating block ${b + 1}/${blocks.length} <${block.tagName.toLowerCase()}>: "${block.textContent?.trim().slice(0, 60)}…"`);
+          console.debug(`[TranslatorButton] Translating block ${b + 1}/${allBlocks.length} <${block.tagName.toLowerCase()}>: "${block.textContent?.trim().slice(0, 60)}…"`);
 
           const translations = await Promise.all(
             textNodes.map((n) => translator.translate(n.textContent ?? ''))
@@ -153,7 +160,7 @@ const isAlreadyEnglish = lang === 'en';
             textNodes[i].textContent = translations[i];
           }
 
-          console.debug(`[TranslatorButton] Block ${b + 1}/${blocks.length} done`);
+          console.debug(`[TranslatorButton] Block ${b + 1}/${allBlocks.length} done`);
         }
 
         console.debug('[TranslatorButton] All blocks translated ✓');

--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -98,6 +98,7 @@ const isAlreadyEnglish = lang === 'en';
       btn.disabled = true;
       label.textContent = 'Translating…';
       icon.textContent = '⏳';
+      icon.classList.add('spinning');
 
       try {
         let translator: TranslatorInstance;
@@ -140,10 +141,12 @@ const isAlreadyEnglish = lang === 'en';
         translated = true;
         label.textContent = 'Show Original';
         icon.textContent = '↩️';
+        icon.classList.remove('spinning');
       } catch (err) {
         console.error('[TranslatorButton]', err);
         label.textContent = 'Translation failed';
         icon.textContent = '⚠️';
+        icon.classList.remove('spinning');
       } finally {
         btn.disabled = false;
       }
@@ -152,3 +155,17 @@ const isAlreadyEnglish = lang === 'en';
 
   init();
 </script>
+
+<style>
+  @keyframes hourglass-spin {
+    0%   { transform: rotate(0deg); }
+    45%  { transform: rotate(0deg); }
+    55%  { transform: rotate(180deg); }
+    100% { transform: rotate(180deg); }
+  }
+
+  .spinning {
+    display: inline-block;
+    animation: hourglass-spin 1.2s ease-in-out infinite;
+  }
+</style>

--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -101,12 +101,14 @@ const isAlreadyEnglish = lang === 'en';
       icon.classList.add('spinning');
 
       try {
+        console.debug('[TranslatorButton] Creating translator…', { sourceLang, targetLang: TARGET_LANG });
         let translator: TranslatorInstance;
         if (hasNewAPI) {
           translator = await window.Translator!.create({ sourceLanguage: sourceLang, targetLanguage: TARGET_LANG });
         } else {
           translator = await window.translation!.createTranslator({ sourceLanguage: sourceLang, targetLanguage: TARGET_LANG });
         }
+        console.debug('[TranslatorButton] Translator ready');
 
         const contentEl = document.querySelector(CONTENT_SELECTOR);
         if (!contentEl) return;
@@ -115,7 +117,10 @@ const isAlreadyEnglish = lang === 'en';
           contentEl.querySelectorAll<HTMLElement>('p, h1, h2, h3, h4, h5, h6, li, blockquote, td, th')
         ).filter((el) => !el.closest('pre'));
 
-        for (const block of blocks) {
+        console.debug(`[TranslatorButton] Found ${blocks.length} blocks to translate`);
+
+        for (let b = 0; b < blocks.length; b++) {
+          const block = blocks[b];
           const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, {
             acceptNode(node) {
               const text = node.textContent?.trim();
@@ -134,6 +139,8 @@ const isAlreadyEnglish = lang === 'en';
           }
           if (!textNodes.length) continue;
 
+          console.debug(`[TranslatorButton] Translating block ${b + 1}/${blocks.length} <${block.tagName.toLowerCase()}>: "${block.textContent?.trim().slice(0, 60)}…"`);
+
           const translations = await Promise.all(
             textNodes.map((n) => translator.translate(n.textContent ?? ''))
           );
@@ -143,8 +150,11 @@ const isAlreadyEnglish = lang === 'en';
             originalNodes.push({ node: textNodes[i], text: original });
             textNodes[i].textContent = translations[i];
           }
+
+          console.debug(`[TranslatorButton] Block ${b + 1}/${blocks.length} done`);
         }
 
+        console.debug('[TranslatorButton] All blocks translated ✓');
         translated = true;
         label.textContent = 'Show Original';
         icon.textContent = '↩️';

--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -1,0 +1,144 @@
+---
+export interface Props {
+  lang?: string;
+}
+
+const { lang = 'id' } = Astro.props;
+const isAlreadyEnglish = lang === 'en';
+---
+
+{
+  !isAlreadyEnglish && (
+    <div id="translator-wrapper" class="hidden">
+      <button
+        id="translator-btn"
+        type="button"
+        class="inline-flex items-center gap-2 rounded-lg border border-current px-3 py-1.5 text-sm font-medium text-captions transition-opacity hover:opacity-70 disabled:cursor-not-allowed disabled:opacity-40"
+        data-source-lang={lang}
+      >
+        <span id="translator-icon" class="shrink-0" aria-hidden="true">
+          🌐
+        </span>
+        <span id="translator-label">Translate to English</span>
+      </button>
+    </div>
+  )
+}
+
+<script>
+  const CONTENT_SELECTOR = '.prose';
+  const TARGET_LANG = 'en';
+
+  type TranslationAPI = {
+    canTranslate: (opts: { sourceLanguage: string; targetLanguage: string }) => Promise<string>;
+    createTranslator: (opts: {
+      sourceLanguage: string;
+      targetLanguage: string;
+    }) => Promise<{ translate: (text: string) => Promise<string> }>;
+  };
+
+  declare global {
+    interface Window {
+      translation?: TranslationAPI;
+    }
+  }
+
+  async function init() {
+    const wrapper = document.getElementById('translator-wrapper');
+    const btn = document.getElementById('translator-btn') as HTMLButtonElement | null;
+    const label = document.getElementById('translator-label');
+    const icon = document.getElementById('translator-icon');
+
+    if (!wrapper || !btn || !label || !icon) return;
+
+    if (!window.translation) return;
+
+    const sourceLang = btn.dataset.sourceLang ?? 'id';
+
+    let availability: string;
+    try {
+      availability = await window.translation.canTranslate({
+        sourceLanguage: sourceLang,
+        targetLanguage: TARGET_LANG,
+      });
+    } catch {
+      return;
+    }
+
+    if (availability === 'no') return;
+
+    wrapper.classList.remove('hidden');
+
+    let translated = false;
+    let originalNodes: { node: Text; text: string }[] = [];
+
+    btn.addEventListener('click', async () => {
+      if (translated) {
+        // restore originals
+        for (const { node, text } of originalNodes) {
+          node.textContent = text;
+        }
+        originalNodes = [];
+        translated = false;
+        label.textContent = 'Translate to English';
+        icon.textContent = '🌐';
+        return;
+      }
+
+      btn.disabled = true;
+      label.textContent = 'Translating…';
+      icon.textContent = '⏳';
+
+      try {
+        const translator = await window.translation!.createTranslator({
+          sourceLanguage: sourceLang,
+          targetLanguage: TARGET_LANG,
+        });
+
+        const contentEl = document.querySelector(CONTENT_SELECTOR);
+        if (!contentEl) return;
+
+        const walker = document.createTreeWalker(contentEl, NodeFilter.SHOW_TEXT, {
+          acceptNode(node) {
+            const text = node.textContent?.trim();
+            if (!text) return NodeFilter.FILTER_SKIP;
+            const parent = node.parentElement;
+            if (!parent) return NodeFilter.FILTER_SKIP;
+            // skip code blocks
+            if (parent.closest('code, pre')) return NodeFilter.FILTER_SKIP;
+            return NodeFilter.FILTER_ACCEPT;
+          },
+        });
+
+        const textNodes: Text[] = [];
+        let node: Text | null;
+        while ((node = walker.nextNode() as Text | null)) {
+          textNodes.push(node);
+        }
+
+        // batch translate all text nodes
+        const translations = await Promise.all(
+          textNodes.map((n) => translator.translate(n.textContent ?? ''))
+        );
+
+        for (let i = 0; i < textNodes.length; i++) {
+          const original = textNodes[i].textContent ?? '';
+          originalNodes.push({ node: textNodes[i], text: original });
+          textNodes[i].textContent = translations[i];
+        }
+
+        translated = true;
+        label.textContent = 'Show Original';
+        icon.textContent = '↩️';
+      } catch (err) {
+        console.error('[TranslatorButton]', err);
+        label.textContent = 'Translation failed';
+        icon.textContent = '⚠️';
+      } finally {
+        btn.disabled = false;
+      }
+    });
+  }
+
+  init();
+</script>

--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -29,17 +29,23 @@ const isAlreadyEnglish = lang === 'en';
   const CONTENT_SELECTOR = '.prose';
   const TARGET_LANG = 'en';
 
-  type TranslationAPI = {
-    canTranslate: (opts: { sourceLanguage: string; targetLanguage: string }) => Promise<string>;
-    createTranslator: (opts: {
-      sourceLanguage: string;
-      targetLanguage: string;
-    }) => Promise<{ translate: (text: string) => Promise<string> }>;
-  };
+  interface TranslatorInstance {
+    translate: (text: string) => Promise<string>;
+  }
+
+  interface TranslatorConstructor {
+    availability: (opts: { sourceLanguage: string; targetLanguage: string }) => Promise<string>;
+    create: (opts: { sourceLanguage: string; targetLanguage: string }) => Promise<TranslatorInstance>;
+  }
 
   declare global {
     interface Window {
-      translation?: TranslationAPI;
+      Translator?: TranslatorConstructor;
+      // older API shape still present in some builds
+      translation?: {
+        canTranslate: (opts: { sourceLanguage: string; targetLanguage: string }) => Promise<string>;
+        createTranslator: (opts: { sourceLanguage: string; targetLanguage: string }) => Promise<TranslatorInstance>;
+      };
     }
   }
 
@@ -51,21 +57,26 @@ const isAlreadyEnglish = lang === 'en';
 
     if (!wrapper || !btn || !label || !icon) return;
 
-    if (!window.translation) return;
-
     const sourceLang = btn.dataset.sourceLang ?? 'id';
 
-    let availability: string;
+    // Detect which API shape is present
+    const hasNewAPI = typeof window.Translator !== 'undefined';
+    const hasOldAPI = typeof window.translation !== 'undefined';
+
+    if (!hasNewAPI && !hasOldAPI) return;
+
+    // Check availability
     try {
-      availability = await window.translation.canTranslate({
-        sourceLanguage: sourceLang,
-        targetLanguage: TARGET_LANG,
-      });
+      let availability: string;
+      if (hasNewAPI) {
+        availability = await window.Translator!.availability({ sourceLanguage: sourceLang, targetLanguage: TARGET_LANG });
+      } else {
+        availability = await window.translation!.canTranslate({ sourceLanguage: sourceLang, targetLanguage: TARGET_LANG });
+      }
+      if (availability === 'no') return;
     } catch {
       return;
     }
-
-    if (availability === 'no') return;
 
     wrapper.classList.remove('hidden');
 
@@ -74,7 +85,6 @@ const isAlreadyEnglish = lang === 'en';
 
     btn.addEventListener('click', async () => {
       if (translated) {
-        // restore originals
         for (const { node, text } of originalNodes) {
           node.textContent = text;
         }
@@ -90,10 +100,12 @@ const isAlreadyEnglish = lang === 'en';
       icon.textContent = '⏳';
 
       try {
-        const translator = await window.translation!.createTranslator({
-          sourceLanguage: sourceLang,
-          targetLanguage: TARGET_LANG,
-        });
+        let translator: TranslatorInstance;
+        if (hasNewAPI) {
+          translator = await window.Translator!.create({ sourceLanguage: sourceLang, targetLanguage: TARGET_LANG });
+        } else {
+          translator = await window.translation!.createTranslator({ sourceLanguage: sourceLang, targetLanguage: TARGET_LANG });
+        }
 
         const contentEl = document.querySelector(CONTENT_SELECTOR);
         if (!contentEl) return;
@@ -104,7 +116,6 @@ const isAlreadyEnglish = lang === 'en';
             if (!text) return NodeFilter.FILTER_SKIP;
             const parent = node.parentElement;
             if (!parent) return NodeFilter.FILTER_SKIP;
-            // skip code blocks
             if (parent.closest('code, pre')) return NodeFilter.FILTER_SKIP;
             return NodeFilter.FILTER_ACCEPT;
           },
@@ -116,7 +127,6 @@ const isAlreadyEnglish = lang === 'en';
           textNodes.push(node);
         }
 
-        // batch translate all text nodes
         const translations = await Promise.all(
           textNodes.map((n) => translator.translate(n.textContent ?? ''))
         );

--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -112,8 +112,7 @@ const isAlreadyEnglish = lang === 'en';
 
         const contentEl = document.querySelector(CONTENT_SELECTOR);
         if (!contentEl) {
-          console.debug('[TranslatorButton] Content element not found:', CONTENT_SELECTOR);
-          return;
+          throw new Error(`Content element not found: ${CONTENT_SELECTOR}`);
         }
 
         const blocks = Array.from(

--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -111,31 +111,38 @@ const isAlreadyEnglish = lang === 'en';
         const contentEl = document.querySelector(CONTENT_SELECTOR);
         if (!contentEl) return;
 
-        const walker = document.createTreeWalker(contentEl, NodeFilter.SHOW_TEXT, {
-          acceptNode(node) {
-            const text = node.textContent?.trim();
-            if (!text) return NodeFilter.FILTER_SKIP;
-            const parent = node.parentElement;
-            if (!parent) return NodeFilter.FILTER_SKIP;
-            if (parent.closest('code, pre')) return NodeFilter.FILTER_SKIP;
-            return NodeFilter.FILTER_ACCEPT;
-          },
-        });
+        const blocks = Array.from(
+          contentEl.querySelectorAll<HTMLElement>('p, h1, h2, h3, h4, h5, h6, li, blockquote, td, th')
+        ).filter((el) => !el.closest('pre'));
 
-        const textNodes: Text[] = [];
-        let node: Text | null;
-        while ((node = walker.nextNode() as Text | null)) {
-          textNodes.push(node);
-        }
+        for (const block of blocks) {
+          const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, {
+            acceptNode(node) {
+              const text = node.textContent?.trim();
+              if (!text) return NodeFilter.FILTER_SKIP;
+              const parent = node.parentElement;
+              if (!parent) return NodeFilter.FILTER_SKIP;
+              if (parent.closest('code, pre')) return NodeFilter.FILTER_SKIP;
+              return NodeFilter.FILTER_ACCEPT;
+            },
+          });
 
-        const translations = await Promise.all(
-          textNodes.map((n) => translator.translate(n.textContent ?? ''))
-        );
+          const textNodes: Text[] = [];
+          let node: Text | null;
+          while ((node = walker.nextNode() as Text | null)) {
+            textNodes.push(node);
+          }
+          if (!textNodes.length) continue;
 
-        for (let i = 0; i < textNodes.length; i++) {
-          const original = textNodes[i].textContent ?? '';
-          originalNodes.push({ node: textNodes[i], text: original });
-          textNodes[i].textContent = translations[i];
+          const translations = await Promise.all(
+            textNodes.map((n) => translator.translate(n.textContent ?? ''))
+          );
+
+          for (let i = 0; i < textNodes.length; i++) {
+            const original = textNodes[i].textContent ?? '';
+            originalNodes.push({ node: textNodes[i], text: original });
+            textNodes[i].textContent = translations[i];
+          }
         }
 
         translated = true;

--- a/src/components/TranslatorButton.astro
+++ b/src/components/TranslatorButton.astro
@@ -26,7 +26,7 @@ const isAlreadyEnglish = lang === 'en';
 }
 
 <script>
-  const CONTENT_SELECTOR = '.prose';
+  const CONTENT_SELECTOR = '.my-prose';
   const TARGET_LANG = 'en';
 
   interface TranslatorInstance {
@@ -111,7 +111,10 @@ const isAlreadyEnglish = lang === 'en';
         console.debug('[TranslatorButton] Translator ready');
 
         const contentEl = document.querySelector(CONTENT_SELECTOR);
-        if (!contentEl) return;
+        if (!contentEl) {
+          console.debug('[TranslatorButton] Content element not found:', CONTENT_SELECTOR);
+          return;
+        }
 
         const blocks = Array.from(
           contentEl.querySelectorAll<HTMLElement>('p, h1, h2, h3, h4, h5, h6, li, blockquote, td, th')

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -29,6 +29,7 @@ const breadcrumbs = [BreadcrumbItemHome, BreadcrumbItemBlog];
       <div class="relative gap-4 lg:grid lg:grid-cols-[minmax(0,1fr),300px]">
         <section
           class="my-prose centered-px post-detail [&>h2:nth-child(1)]:mt-0 [&>h2:nth-child(3)]:mt-0"
+          data-translatable="content"
         >
           <content-wrapper><slot name="content" /></content-wrapper>
         </section>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -11,6 +11,7 @@ import PostListMore from '@/components/PostListMore.astro';
 import PostMeta from '@/components/PostMeta.astro';
 import Share from '@/components/Share.astro';
 import TagList from '@/components/TagList.astro';
+import TranslatorButton from '@/components/TranslatorButton.astro';
 import ToC from '@/components/ToC.astro';
 import { DRAFT_TEXT } from '@/constants/data';
 import { IMAGE_SIZES } from '@/constants/image';
@@ -53,6 +54,7 @@ const {
   heroAlt,
   noHero,
   category,
+  lang,
   tags = [],
 } = data;
 
@@ -173,6 +175,7 @@ const schema = JSON.stringify({
     <div class="b-h2-mb mt-4 flex flex-col items-start gap-6 md:flex-row md:items-center">
       <TagList tags={tags} size="md" />
       <Share {...shareProps} />
+      <TranslatorButton lang={lang} />
     </div>
 
     <Giscus class="b-h2-mt" />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -166,8 +166,10 @@ const schema = JSON.stringify({
       })}
     />
 
-    <TagList tags={tags} size="md" class="mt-4" />
-    <TranslatorButton lang={lang} />
+    <div class="mt-4 flex flex-wrap items-center gap-3">
+      <TagList tags={tags} size="md" />
+      <TranslatorButton lang={lang} />
+    </div>
   </Fragment>
 
   <Fragment slot="content">

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -137,6 +137,8 @@ const schema = JSON.stringify({
 
   <Fragment slot="hero-text">
     <h1
+      id="post-title"
+      data-translatable="title"
       class="b-h1 mb-3 mt-0 tracking-wide"
       transition:name={getTransitionNameFromElementId({
         elementId: TRANSITION_ELEMENT_IDS.POST_CARD.TITLE,
@@ -149,6 +151,8 @@ const schema = JSON.stringify({
     {
       description && (
         <p
+          id="post-description"
+          data-translatable="description"
           class="mb-6 text-lg font-normal text-captions md:mb-8 md:text-xl"
           transition:name={getTransitionNameFromElementId({
             elementId: TRANSITION_ELEMENT_IDS.POST_CARD.DESCRIPTION,

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -165,6 +165,9 @@ const schema = JSON.stringify({
         elementId: TRANSITION_ELEMENT_IDS.POST_CARD.META,
       })}
     />
+
+    <TagList tags={tags} size="md" class="mt-4" />
+    <TranslatorButton lang={lang} />
   </Fragment>
 
   <Fragment slot="content">
@@ -173,9 +176,7 @@ const schema = JSON.stringify({
 
   <Fragment slot="after-content">
     <div class="b-h2-mb mt-4 flex flex-col items-start gap-6 md:flex-row md:items-center">
-      <TagList tags={tags} size="md" />
       <Share {...shareProps} />
-      <TranslatorButton lang={lang} />
     </div>
 
     <Giscus class="b-h2-mt" />


### PR DESCRIPTION
## Summary
This PR adds a new `TranslatorButton` component that enables readers to translate blog post content to English using the browser's built-in Translation API.

## Key Changes
- **New Component**: Created `TranslatorButton.astro` component that:
  - Displays a translation button for non-English blog posts
  - Uses the browser's native Translation API (`window.translation`) to translate content
  - Intelligently walks the DOM to find and translate text nodes while skipping code blocks
  - Provides toggle functionality to switch between translated and original content
  - Shows appropriate UI feedback during translation (loading state, error handling)
  - Gracefully degrades if the Translation API is unavailable

- **Blog Post Integration**: Updated `src/pages/blog/[slug].astro` to:
  - Import and render the `TranslatorButton` component
  - Pass the `lang` property from frontmatter to the button
  - Position the button alongside existing post metadata (tags and share options)

## Implementation Details
- The component accepts an optional `lang` prop (defaults to 'id' for Indonesian) and only renders if the post is not already in English
- Uses a TreeWalker to efficiently traverse text nodes while filtering out code blocks and empty text
- Batches translation requests for all text nodes in parallel for better performance
- Maintains original text content to allow users to toggle back to the original language
- Includes visual indicators (emoji icons) for different states: default (🌐), translating (⏳), and error (⚠️)
- Respects the browser's Translation API availability and gracefully handles unsupported language pairs

https://claude.ai/code/session_01UujJ9x1LTy1CsM3eBJZtpE