### PR TITLE
feat: add Cache-Control header to OG image response

### DIFF
--- a/src/pages/api/open-graph/[...route].png.ts
+++ b/src/pages/api/open-graph/[...route].png.ts
@@ -93,7 +93,12 @@ export const GET: APIRoute = async ({ props, params }: APIContext) => {
 
   const pngBuffer = await sharp(Buffer.from(svg)).png().toBuffer();
 
-  return new Response(new Uint8Array(pngBuffer));
+  return new Response(new Uint8Array(pngBuffer), {
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
 };
 
 /*-------------------------------- utils ------------------------------*/


### PR DESCRIPTION
Set public, max-age=31536000, immutable so browsers and CDNs cache
the statically generated OG images aggressively.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CUZyPtctKCApJ3iL7P9KLC