### PR TITLE
chore: add grouping to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,24 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      astro:
+        patterns:
+          - 'astro'
+          - '@astrojs/*'
+      linting:
+        patterns:
+          - 'eslint*'
+          - '@eslint/*'
+          - 'prettier*'
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@typescript-eslint/*'
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -15,3 +33,7 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+      - 'dependabot'
+      - 'automerge'
     groups:
       astro:
         patterns:
@@ -33,6 +37,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+      - 'dependabot'
+      - 'automerge'
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Group npm updates by ecosystem (astro, linting, typescript) and catch remaining minor/patch updates in a shared group. Group all GitHub Actions updates into a single PR.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XqWjCnyyB3V5fLquRW53vw